### PR TITLE
Iron out corner cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ Software dependencies
   * numpy
   * pandas
   * matplotlib
+  * jinja2
+  * lxml
   * beautifulsoup4
   * elasticsearch
-  * elasticsearch_dsl
+  * elasticsearch-dsl
 
 Infrastructure
 * Access to ELK server with the logstash of your job scheduler
-* Access to VSC Account page (optional)
+* Access to VSC Account page
 
 ## Data Sources
 

--- a/lib/vsc/accounting/counters.py
+++ b/lib/vsc/accounting/counters.py
@@ -403,7 +403,8 @@ class ComputeTimeCount:
         - percent_name: (string) name of column to save percentage data
         """
         source_data = self.getattr(source)
-        percent_data = source_data.loc[:, absolute] / source_data.loc[:, reference]
+        # Calculate percentage avoiding divides by zero and replacing NaN with zeros
+        percent_data = source_data.loc[:, absolute] / source_data.loc[:, reference].replace({0: float('nan')})
         percent_data = percent_data.fillna(0)
 
         if not percent_name:

--- a/lib/vsc/accounting/counters.py
+++ b/lib/vsc/accounting/counters.py
@@ -245,7 +245,7 @@ class ComputeTimeCount:
             count_computejobsusers,  # worker function
             f"'{nodegroup}' compute/job counter",  # label prefixing log messages
             ng_index.levels[0],  # stack of items to process
-            {nodegroup: self.NG[nodegroup]},  # nodegroup_spec: forwarded to worker function
+            (nodegroup, self.NG[nodegroup]),  # nodegroup_spec: forwarded to worker function
             procs=self.max_procs,
             logger=self.log,
             peruser=True,  # forwarded to worker function
@@ -532,9 +532,9 @@ def count_computejobsusers(period_start, nodegroup_spec, peruser=False, logger=N
     Returns dict with global counters on running jobs, unique users and compute time
     Data source is a list of running jobs in the given time period and in the given nodegroup
     - period_start: (pd.timestamp) start of time interval
-    - nodegroup_spec: (dict) {nodegroup: [hosts]}
-      - hosts: (list) [{regex: hostname pattern, n: number of nodes, start: date string, end: date string}]
+    - nodegroup_spec: (tuple) (nodegroup: [hosts])
       - nodegroup: (string) name of group of nodes
+      - hosts: (list) [{regex: hostname pattern, n: number of nodes, start: date string, end: date string}]
     - peruser: (boolean) return additional dicts with stats per user
     - logger: (object) fancylogger object of the caller
     """
@@ -542,7 +542,7 @@ def count_computejobsusers(period_start, nodegroup_spec, peruser=False, logger=N
         logger = fancylogger.getLogger()
 
     # Unpack nodegroup_spec
-    ((nodegroup, ng_hosts),) = nodegroup_spec.items()
+    (nodegroup, ng_hosts) = nodegroup_spec
 
     # Define length of current period
     period_end = period_start + period_start.freq
@@ -618,7 +618,7 @@ def get_joblist_ES(query_id, period_start, nodegroup_spec, logger=None):
     Calculates used compute time by jobs in the period of time
     - query_id: (int) arbitrary identification number of the query
     - period_start: (pd.timestamp) start of time interval
-    - nodegroup_spec: (dict) {nodegroup: [hosts]}
+    - nodegroup_spec: (tuple) (nodegroup: [hosts])
       - nodegroup: (string) name of group of nodes
       - hosts: (list) [{regex: hostname pattern, n: number of nodes, start: date string, end: date string}]
     - logger: (object) fancylogger object of the caller
@@ -627,7 +627,7 @@ def get_joblist_ES(query_id, period_start, nodegroup_spec, logger=None):
         logger = fancylogger.getLogger()
 
     # Unpack nodegroup_spec
-    ((nodegroup, ng_hosts),) = nodegroup_spec.items()
+    (nodegroup, ng_hosts) = nodegroup_spec
 
     # Define length of current period
     period_end = period_start + period_start.freq
@@ -686,7 +686,7 @@ def corecount(nodegroup_spec, job_hosts, totalcores=None):
     If all hosts match returns totalcores (if provided)
     Otherwise, it counts the number of cores in matching hosts
     - job_hosts: (list) hostnames allocated to job
-    - nodegroup_spec: (dict) {nodegroup: [hosts]}
+    - nodegroup_spec: (tuple) (nodegroup: [hosts])
       - nodegroup: (string) name of group of nodes
       - hosts: (list) [{regex: hostname pattern, n: number of nodes, start: date string, end: date string}]
     - totalcores: (integer) number of cores used by job
@@ -695,7 +695,7 @@ def corecount(nodegroup_spec, job_hosts, totalcores=None):
     corecount = 0
 
     # Unpack nodegroup_spec
-    ((nodegroup, ng_hosts),) = nodegroup_spec.items()
+    (nodegroup, ng_hosts) = nodegroup_spec
 
     # Take core specification for job hosts matching current node group
     for node in ng_hosts:

--- a/lib/vsc/accounting/data/userdb.py
+++ b/lib/vsc/accounting/data/userdb.py
@@ -151,13 +151,17 @@ class UserDB:
 # See issue: https://bugs.python.org/issue29423
 
 
-def user_basic_record(username):
+def user_basic_record(username, logger=None):
     """
     Generate basic user record from user name
     All VSC IDs are ascribed to their site, other usernames are identified as NetID users from ULB
     WARNING: old NetIDs from VUB without a VSC account are suposed to be already accounted in the cache file
     - username: (string) username of the account
+    - logger: (object) fancylogger object of the caller
     """
+    if logger is None:
+        logger = fancylogger.getLogger()
+
     # Research field is always unknown in these cases
     user_record = {'field': 'Unknown'}
 

--- a/lib/vsc/accounting/data/userdb.py
+++ b/lib/vsc/accounting/data/userdb.py
@@ -79,8 +79,15 @@ class UserDB:
         except KeyError as err:
             error_exit(self.log, err)
 
-        # Load all user data base from local cache
+        # Load user data base from local cache
         self.cache = self.load_db_cache()
+
+        # Update list of users with their records in the cache
+        for n, user in enumerate(self.users):
+            if user in self.cache.contents['db']:
+                self.users[n] = (user, self.cache.contents['db'][user])
+            else:
+                self.users[n] = (user, None)
 
         # Retrieve account data of requested users
         self.log.info(f"Retrieving {len(self.users)} user account records...")
@@ -88,7 +95,7 @@ class UserDB:
             get_updated_record,  # worker function
             f"User account retrieval",  # label prefixing log messages
             self.users,  # stack of items to process
-            self.cache.contents,  # user_cache: forwarded to worker function
+            self.cache.contents['valid_days'],  # record_validity: forwarded to worker function
             self.vsc_token,  # vsc_token: forwarded to worker function
             procs=self.max_procs,
             logger=self.log,
@@ -226,49 +233,51 @@ def get_vsc_record(username, vsc_token, logger=None):
         return user_record
 
 
-def get_updated_record(username, user_cache, vsc_token, logger=None):
+def get_updated_record(user_record, record_validity, vsc_token, logger=None):
     """
     Return user record with up to date information
     First check local cache. If missing or outdated check VSC account page
-    - username: (string) username of the account
-    - user_cache: (dict) data base of user accounts
+    - user_record: (tuple) username and its account record
+    - record_validity: (int) number of days that user records are valid
     - vsc_token: (string) access token to VSC account page
     - logger: (object) fancylogger object of the caller
     """
     if logger is None:
         logger = fancylogger.getLogger()
 
+    # Unpack user record
+    (username, record_data) = user_record
+
     # Existing user
-    if username in user_cache['db']:
-        # Retrieve record from existing local cache
-        user_record = user_cache['db'][username]
-        logger.debug(f"[{username}] user account record retrieved from local cache")
+    if record_data:
+        logger.debug(f"[{username}] user account record exists in local cache")
 
         try:
+            # Calculate age of existing record
             # Once we can use Python 3.7+, the following can be replaced with date.fromisoformat()
-            record_date = datetime.strptime(user_record['updated'], '%Y-%m-%d').date()
+            record_date = datetime.strptime(record_data['updated'], '%Y-%m-%d').date()
         except ValueError as err:
             errmsg = f"[{username}] user account record in local cache is malformed"
             error_exit(logger, errmsg)
         else:
             record_age = date.today() - record_date
 
-        if record_age.days > user_cache['valid_days']:
+        if record_age.days > record_validity:
             fresh_record = get_vsc_record(username, vsc_token)
             if fresh_record:
                 # Update outdated record with data from VSC account page
-                user_record.update(fresh_record)
+                record_data.update(fresh_record)
                 logger.debug(f"[{username}] user account record updated from VSC account page")
             else:
                 # Account missing in VSC account page, keep existing record in our data base
-                user_record['updated'] = date.today().isoformat()
+                record_data['updated'] = date.today().isoformat()
     # New user
     else:
         # Retrieve full record from VSC account page
-        user_record = get_vsc_record(username, vsc_token)
-        if not user_record:
+        record_data = get_vsc_record(username, vsc_token)
+        if not record_data:
             # Generate a default record for users not present in VSC account page
-            user_record = user_basic_record(username)
-            logger.debug(f"[{username}] new user account registered as member of {user_record['site']}")
+            record_data = user_basic_record(username)
+            logger.debug(f"[{username}] new user account registered as member of {record_data['site']}")
 
-    return {username: user_record}
+    return {username: record_data}

--- a/lib/vsc/accounting/data/userdb.py
+++ b/lib/vsc/accounting/data/userdb.py
@@ -155,10 +155,11 @@ def user_basic_record(username):
     user_record = {'field': 'Unknown'}
 
     # Determine site of account
-    site_index = (BRUSSEL, ANTWERPEN, LEUVEN, GENT)
+    site = (None, BRUSSEL, ANTWERPEN, LEUVEN, GENT)
 
     if username[0:3] == 'vsc' and username[3].isdigit():
-        user_record.update({'site': INSTITUTE_LONGNAME[site_index[vsc_id[3]]]})
+        user_site_index = int(username[3])
+        user_record.update({'site': INSTITUTE_LONGNAME[site[user_site_index]]})
     else:
         user_record.update({'site': "Université Libre de Bruxelles"})
 

--- a/lib/vsc/accounting/data/userdb.py
+++ b/lib/vsc/accounting/data/userdb.py
@@ -167,6 +167,7 @@ def user_basic_record(username):
     if username[0:3] == 'vsc' and username[3].isdigit():
         user_site_index = int(username[3])
         user_record.update({'site': INSTITUTE_LONGNAME[site[user_site_index]]})
+        logger.warning(f"[{username}] account not found in VSC account page, record added with site information only")
     else:
         user_record.update({'site': "Université Libre de Bruxelles"})
 

--- a/lib/vsc/accounting/plotter.py
+++ b/lib/vsc/accounting/plotter.py
@@ -328,11 +328,10 @@ class Plotter:
         It needs to be calculated because DatetimeIndexes loose the freq attribute in Multiindexes
         """
         # Number of days between consecutive dates
+        day_span = 0
         if 'date' in self.table.index.names:
             dateidx = self.table.index.get_level_values('date').unique()
             day_span = (dateidx[1] - dateidx[0]).days
-        else:
-            day_span = 0
 
         # Frequency label
         if day_span == 1:

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -422,15 +422,21 @@ def top_users(ComputeTime, percent, savedir, plotformat, csv=False):
         {'thrs': 0.01, 'color': '#4ffbdf'},
     ]
 
-    # Generate area plot stacks
+    # Generate percentile stacks for the area plot
     plot_stacks = dict()
 
+    # Calculate users in each percentile
     for pctl in user_percentile:
-        # Users in this percentile
-        pctl['name'] = (column_title[0], column_title[1].format(pctl['thrs']))
         pctl['user_num'] = int(np.around(len(top_users.index) * pctl['thrs'], 0))
-        pctl_user_list = top_users.iloc[: pctl['user_num']]
+
+    # Remove unpopulated percentiles
+    user_percentile = [pctl for pctl in user_percentile if pctl['user_num'] > 0]
+
+    # Calculate compute stats per percentile
+    for pctl in user_percentile:
+        pctl['name'] = (column_title[0], column_title[1].format(pctl['thrs']))
         # Add total percentage compute for this percentile of users (used in legend)
+        pctl_user_list = top_users.iloc[: pctl['user_num']]
         pctl['compute_used'] = pctl_user_list['compute_percentile'][-1]
         # Calculate total compute time used by users in this percentile
         pctl_compute = ComputeTime.UserCompute.loc[:, pctl_user_list.index].groupby('date').sum().sum(axis=1)

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -131,7 +131,7 @@ def compute_percent(ComputeTime, colorlist, savedir, plotformat, csv=False):
         'compute_time': f"Compute Time ({ComputeTime.compute_units['name']})",
         'capacity': f"Capacity ({ComputeTime.compute_units['name']})",
         'percent_capacity': "Capacity Used (%)",
-        'total_capacity': f"Total Capacity (ComputeTime.compute_units['name'])",
+        'total_capacity': f"Total Capacity ({ComputeTime.compute_units['name']})",
         'percent_total_capacity': "Total Capacity Used (%)",
         'global_percent_capacity': "Total Capacity Used Globally (%)",
     }

--- a/lib/vsc/accounting/reports.py
+++ b/lib/vsc/accounting/reports.py
@@ -254,7 +254,7 @@ def aggregates(ComputeTime, aggregate, selection, percent, colorlist, savedir, p
 
     # Source data for selected accounting and aggregate
     try:
-        sources = source_data(selection, aggregate)
+        sources = source_data(selection, aggregate, ComputeTime.compute_units['name'])
     except AttributeError as err:
         error_exit(logger, err)
 
@@ -822,18 +822,19 @@ def simple_names_units(names, units=None):
     return name_titles
 
 
-def source_data(counter, aggregate):
+def source_data(counter, aggregate, compute_units):
     """
     Return dict with names of objects that hold source data to generate an aggregate accounting
     - counter: (string) name of global data in the accounting
     - aggregate: (string) name of aggregate criteria
+    - compute_units: (string) long name of compute units
     """
     sources = dict()
 
     # Source of accounting data
     if counter == 'Compute':
         sources.update({'reference': 'compute_time'})
-        sources.update({'units': ComputeTime.compute_units['name']})
+        sources.update({'units': compute_units})
     elif counter == 'Jobs':
         sources.update({'reference': 'running_jobs'})
         sources.update({'units': 'jobs/day'})

--- a/lib/vsc/accounting/version.py
+++ b/lib/vsc/accounting/version.py
@@ -29,4 +29,4 @@ Version of vsc.accounting
 @author: Alex Domingo (Vrije Universiteit Brussel)
 """
 
-VERSION = '1.0.5'
+VERSION = '1.0.6'

--- a/setup.py
+++ b/setup.py
@@ -54,13 +54,13 @@ PACKAGE = {
         # needed to manage config files
         'appdirs',
         # needed to process accounting data
-        'numpy >= 1.14.0',
+        'numpy >= 1.12.0',
         'pandas >= 0.23.0, < 1.0.0',  # v1.0 breaks current use of freq attr in DatetimeIndex
         # needed to retrieve accounting data
         'elasticsearch >= 7.0.0',
-        'elasticsearch_dsl >= 7.0.0',
+        'elasticsearch-dsl >= 7.0.0',
         # needed to render HTML pages
-        'beautifulsoup4 >= 4.6.0',
+        'beautifulsoup4 >= 4.4.0',
         'lxml',
         'jinja2',
         # needed to render plots


### PR DESCRIPTION
The stats of `gbonte` revealed a few corner cases that were not well covered. This is the changelog

* Bug fixes
  * https://github.com/sisc-hpc/vsc-accounting-brussel/commit/f4ed268efbdba0b691e32e61ef0c79e6eb87cded fixes the site assigned to those VSC account that cannot be retrieved from VSC account page (which has never happened yet)
  * https://github.com/sisc-hpc/vsc-accounting-brussel/commit/9d3c92e8bb5ed30f37c0c5f225743c6ec745d54e avoids generating an infinite in calculations of percentages, which can happen if the capacity of the nodegroup in the current date is zero
  * https://github.com/sisc-hpc/vsc-accounting-brussel/commit/1d26fe7091c7727ec334c05f7e03f8f191fe165a discard percentiles in the `top-users` report that have zero users
  * https://github.com/sisc-hpc/vsc-accounting-brussel/commit/8564626f4f79746b8fd3add92de501d4f738cfda explicitly order the data frame with user stats per date, otherwise the date frequency (daily, weekly,...) shown in the plot can be wrong
  * https://github.com/sisc-hpc/vsc-accounting-brussel/commit/482c32aa5331fb38a42e6589310eb6ae73f7f8a5, https://github.com/sisc-hpc/vsc-accounting-brussel/commit/ffbbba19b8a0e46af374965e9f495c8dc26b2b3f use compute units from the `ComputeTime` object of the plot
* Enhancements
  * https://github.com/sisc-hpc/vsc-accounting-brussel/commit/968757e9fb0a24fe57b600e3a4227573f84be663 make compatible with CentOS 7
  * https://github.com/sisc-hpc/vsc-accounting-brussel/commit/66dfedb0e1ed4907917ae0f1d63174414f98f435 pass individual records to workers spawned by `UserDB` instead of the full cache of users
* Code cleanup: https://github.com/sisc-hpc/vsc-accounting-brussel/commit/cd16040e8c335680ac13c7ab3b0e5223390336cb, https://github.com/sisc-hpc/vsc-accounting-brussel/commit/5aa75d29a52c959ec6f6eaba1c33b00a4e91df83